### PR TITLE
Fix failing tests

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,7 @@ brews = pristine-5.16
 [Prereqs]
 parent           = 0
 perl             = 5.8.8
-App::Cmd         = 0
+App::Cmd         = 0.321
 Bash::Completion = 0
 Class::Load      = 0
 [Prereqs / TestRequires]

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -9,7 +9,7 @@ my $tester = Bash::Completion::Plugin::Test->new(
     plugin => 'Bash::Completion::Plugins::TestCommand',
 );
 
-$tester->check_completions('test-command ^', [qw/init foo bar baz --help -h -? commands help/]);
+$tester->check_completions('test-command ^', [qw/init foo bar baz --version --help -h -? commands help version/]);
 $tester->check_completions('test-command i^', [qw/init/]);
 $tester->check_completions('test-command b^', [qw/bar baz/]);
-$tester->check_completions('test-command -^', [qw/--help -h -?/]);
+$tester->check_completions('test-command -^', [qw/--version --help -h -?/]);


### PR DESCRIPTION
Tests were failing with modern versions of `App::Cmd` that generate a `version` command.  Now requiring at least that version and updated the tests accordingly.
